### PR TITLE
Enables CLI feature needed by uniffi_bindgen_main()

### DIFF
--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -10,7 +10,7 @@ build = "build.rs"
 
 [dependencies]
 dnssec-prover = { path = "../", default-features = false, features = ["validation", "std"] }
-uniffi = { version = "0.27", default-features = false }
+uniffi = { version = "0.27", default-features = false, features = ["cli"] }
 
 [build-dependencies]
 uniffi = { version = "0.27", features = [ "build" ] }


### PR DESCRIPTION
Small modification to the `uniffi/Cargo.toml` file by enabling the `cli` feature for the `uniffi` dependency. This is needed to generate Python (and potentially other language) bindings.